### PR TITLE
Treats python docstrings like comments

### DIFF
--- a/Theme - Flatland/Flatland.tmtheme
+++ b/Theme - Flatland/Flatland.tmtheme
@@ -58,6 +58,19 @@
 				<string>#798188</string>
 			</dict>
 		</dict>
+	        <dict>
+			<key>name</key>
+			<string>Python Docstring</string>
+			<key>scope</key>
+			<string>string.quoted.double.block.python</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#798188</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Constant</string>


### PR DESCRIPTION
Fixes #10 by making sure docstrings are shown as if there were comments.
