### PR TITLE
Small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Flatland is a Sublime package. To install it:
 ```javascript
 {
   "theme": "Flatland.sublime-theme",
-  "color_scheme": "Packages/Theme - Flatland/Flatland.tmtheme"
+  "color_scheme": "Packages/Theme - Flatland/Flatland.tmTheme"
 }
 ```
 


### PR DESCRIPTION
Flatland.tmtheme should be Flatland.tmTheme -- Caused an error for me when I copy-pasted.
