### PR TITLE
Font sizes and hinting

### DIFF
--- a/Theme - Flatland/Flatland.sublime-theme
+++ b/Theme - Flatland/Flatland.sublime-theme
@@ -65,7 +65,7 @@
         "fade": false,
         "fg": [144, 146, 147],
         "font.bold" : false,
-        "font.size" : 11.55
+        "font.size" : 12
     },
     {
         "class": "tab_label",


### PR DESCRIPTION
On my non-retina Macbook, the `11.55` font size for `tab_label` looks blurry. The font hinting is better for even font sizes, so I changed it to 12.
