### PR TITLE
Improve caret visibility

### DIFF
--- a/Theme - Flatland/Flatland-Monokai.tmTheme
+++ b/Theme - Flatland/Flatland-Monokai.tmTheme
@@ -12,7 +12,7 @@
 				<key>background</key>
 				<string>#26292C</string>
 				<key>caret</key>
-				<string>#F8F8F0</string>
+				<string>#FFFFFF</string>
 				<key>foreground</key>
 				<string>#F8F8F2</string>
 				<key>invisibles</key>

--- a/Theme - Flatland/Flatland.tmTheme
+++ b/Theme - Flatland/Flatland.tmTheme
@@ -14,7 +14,7 @@
 				<string>#26292C</string>
 
 				<key>caret</key>
-				<string>#646769</string>
+				<string>#FFFFFF</string>
 
 				<key>foreground</key>
 				<string>#F8F8F8</string>


### PR DESCRIPTION
Love the theme. After using it for a couple of days though I find it's very hard to see where your cursor is if you're not following carefully - especially if you're trying to jump to a point on a line.

This changes the caret colour to #FFFFF from #F8F8F0. IMHO this looks good and makes the cursor very easy to spot.

![screenshot](http://i.imgur.com/2DtHaX2.png)
