### PR TITLE
Fixed Red Background on Quick Switch Project menu

### DIFF
--- a/Flatland Dark.sublime-theme
+++ b/Flatland Dark.sublime-theme
@@ -648,7 +648,7 @@
     {
         "class": "quick_panel",
         "row_padding": [5, 2],
-        "layer0.tint": [252, 0, 0],
+        "layer0.tint": [49, 52, 55],
         "layer0.opacity": 1.0
     },
     {


### PR DESCRIPTION
I changed the background of the quick switch project menu from the eye piercing red noted in https://github.com/thinkpixellab/flatland/issues/36 to the shade of grey used by the sidebar.
