### PR TITLE
Increase brightness of selection in dark color scheme

### DIFF
--- a/Flatland Dark.tmTheme
+++ b/Flatland Dark.tmTheme
@@ -26,7 +26,7 @@
 				<string>#202325</string>
 
 				<key>selection</key>
-				<string>#3C3F42</string>
+				<string>#515559</string>
 
 				<key>findHighlight</key>
 				<string>#ffe792</string>


### PR DESCRIPTION
I know it is possible for users to customize this in their own installs, but I'm wondering if you'd consider increasing the brightness of the selection background for the dark color scheme.  I find that bumping the brightness from ~25% to 40% makes selected text much easier to find while still allowing enough contrast with the font.

Without this change (one instance of `this.loadState_` is selected):
![word-before](https://f.cloud.github.com/assets/41094/1546147/c0a5ab22-4d80-11e3-889c-405bff028e8a.png)

With this change:
![word-after](https://f.cloud.github.com/assets/41094/1546149/c91f32e6-4d80-11e3-9f3f-9e781f6b7f80.png)

Thanks for the wonderful theme.
