### PR TITLE
fix vim colorscheme name.

### DIFF
--- a/Vim/colors/flatland.vim
+++ b/Vim/colors/flatland.vim
@@ -8,7 +8,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "PlasticCodeWrap"
+let g:colors_name = "flatland"
 
 hi Cursor ctermfg=16 ctermbg=59 cterm=NONE guifg=#26292c guibg=#646769 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#3c3f42 gui=NONE


### PR DESCRIPTION
otherwise, vim would report the colorscheme "PlasticWrapCode"
is not exits.
