### PR TITLE
Fixed content_margin of tab_control

### DIFF
--- a/Flatland Dark.sublime-theme
+++ b/Flatland Dark.sublime-theme
@@ -23,7 +23,7 @@
     // Tab element
     {
         "class": "tab_control",
-        "content_margin": [28, 6, 28, 4],
+        "content_margin": [28, 0, 28, 6],
         "max_margin_trim": 0,
         "hit_test_level": 0.5,
         // Inactive tab settings


### PR DESCRIPTION
Currently, when I set the sublime setting, "show_tab_close_buttons" to false, tab control of this theme looks like this

![2014-01-08 20 29 35](https://f.cloud.github.com/assets/1506738/1867825/eb13f19e-7859-11e3-8455-e158243b1a3e.png)

I think the font of file name is too close to the bottom of tab. 
So, i change the content_margin of tab_control and It will looks like this

![2014-01-08 20 34 03](https://f.cloud.github.com/assets/1506738/1867835/18ecd4f0-785a-11e3-80a0-f3970108ba45.png)

and when I turned "show_tab_close_buttons" to true, nothing changes before i change content_margin :) 
