### PR TITLE
Unified python string color to single quote one.

### DIFF
--- a/Flatland Dark.tmTheme
+++ b/Flatland Dark.tmTheme
@@ -60,19 +60,6 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Python Docstring</string>
-			<key>scope</key>
-			<string>string.quoted.double.block.python</string>
-			<key>settings</key>
-			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>foreground</key>
-				<string>#798188</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
 			<string>Constant</string>
 			<key>scope</key>
 			<string>constant</string>


### PR DESCRIPTION
Python double quote strings were colored as comments.
Removed "Python Doc" dict from Flatland Dark removes this oddity.