### PR TITLE
Fix errror parsing theme

### DIFF
--- a/Flatland Dark.sublime-theme
+++ b/Flatland Dark.sublime-theme
@@ -612,11 +612,15 @@
 //
     {
         "class": "icon_file_type",
-        "content_margin": [0,0]
+        "content_margin": [0,0],
+        "layer0.opacity": 1.0
+
+        
     },
     {
         "class": "icon_folder",
-        "content_margin": [0,0]
+        "content_margin": [0,0],
+        "layer0.opacity": 1.0
     },
     {
         "class": "icon_folder_loading",


### PR DESCRIPTION
fix the following:
```
Errors parsing theme:
icon_file_type is missing layer0.opacity, setting to 1.0 for backwards compatibility
icon_folder is missing layer0.opacity, setting to 1.0 for backwards compatibility
```

startup, version: 3176 linux x64 channel: stable
